### PR TITLE
 more and more doing a personalized sniffer

### DIFF
--- a/lib/csv_sniffer/dialect.ex
+++ b/lib/csv_sniffer/dialect.ex
@@ -9,10 +9,10 @@ defmodule CsvSniffer.Dialect do
   @type t :: %__MODULE__{
           delimiter: String.t(),
           quote_character: String.t(),
-          double_quote: boolean()
+          quote_needed: boolean()
         }
 
   defstruct delimiter: nil,
-            quote_character: "\"",
-            double_quote: false
+            quote_character: nil,
+            quote_needed: false
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule CsvSniffer.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/doofinder/csv_sniffer"
-  @version "0.2.2"
+  @version "0.2.3"
 
   def project do
     [


### PR DESCRIPTION
quite a few changes:
  - let the old code figure out delimiter and quote_character
  - if quote_character is really needed, set `quote_needed` to `true` `quote_character` is needed when:
    * there are escaped quotes inside fields
    * there are delimiter inside fields
    * there are carriage returns inside fields
  - if quote_character is not needed, set it to `nil` because it will give a lot of trouble when using it as a "escape character' in `NimbleCSV`