### PR TITLE
upgrade github actions due deprecation notice

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -35,9 +35,9 @@ jobs:
       - name: test
         run: mix test --cover --trace
       - name: archive code coverage
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
-          name: cover
+          name: cover-${{ matrix.runs-on }}
           path: cover
 
   static_code_analysis:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -54,7 +54,7 @@ jobs:
           mix local.hex --force
           mix deps.get --only dev
       - name: plt cache
-        uses: actions/cache@v1.1.0
+        uses: actions/cache@v4
         with:
           path: _build
           key: ${{ runner.os }}-plt-${{ env.GITHUB_REF }}


### PR DESCRIPTION
`actions/upload-artifact@v3` is going to be deprecated soon, this PR upgrades to v4 following this guide 
https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md